### PR TITLE
feat: add LIP-17

### DIFF
--- a/LIPS/lip-17.md
+++ b/LIPS/lip-17.md
@@ -1,0 +1,351 @@
+---
+lip: 17
+title: MEV-Boost relays whitelist for Lido
+status: Draft
+author: George Avsetsyn, Artem Veremeenko, Eugene Mamin, Isidoros Passadis
+discussions-to: TBA
+created: 2022-08-30
+updated: 2022-09-02
+---
+
+# MEV-Boost relays whitelist for Lido
+
+>DISCLAIMER. [MEV extraction policy](https://research.lido.fi/t/discussion-draft-for-lido-on-ethereum-block-proposer-rewards-policy/2817
+) for Lido DAO is an ongoing topic and not finalized yet. This proposal is about additional tech spairs.
+
+## Simple Summary
+
+The on-chain relays whitelist is planned to be used by Node Operators participating in the Lido protocol after the Merge to extract MEV according to the expected Lido policies.
+
+## Motivation
+
+It's proposed that Node Operators should use [`MEV-Boost`](https://github.com/flashbots/mev-boost) infrastructure developed by Flashbots to support MEV extraction through the open market mechanics as a current PBS solution that has a market fit.
+
+The proposed whitelist is intented to be a source of truth for the set of possible relays allowed to be used by Node Operators. In particular, Node Operators would use the contract to keep their software configuration up-to-date (setting the necessary relays once Lido DAO decides to update the set).
+
+## Mechanics
+
+The contract represents a simple registry storage.
+
+The storage could be accessed by anyone in a permissionless way through the disclosed `view` methods or by collecting the emitted events covering all storage modifications.
+
+Any modification of the set (i.e. internal storage modification) is allowed only by [the general Lido DAO governance process](https://lido.fi/governance#regular-process) which implemented on-chain through the Aragon voting from the initial deployment stage. However, it's still possible to assign a dedicated management entity for adding/removing relay items.
+
+The proposed `MEVBoostRelayWhitelist` contract is non-upgradable and its immutable owner is intented to be initialized with the [Lido DAO Aragon Agent](https://etherscan.io/address/0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) address on mainnet upon the deployment phase.
+
+The dedicated management `manager` entity is initialized with zero address and can be set later by the contract's owner to be able to add/remove relays. The possible candidate to bear such responsibilities without sacrificing governance security is [Easy Track](https://easytrack.lido.fi/) (in this case  [`EVMScriptExecutor (Easy Track)`](https://docs.lido.fi/deployed-contracts#easy-track) should be set as `manager`).
+
+### Relay information structure
+
+It's proposed to use the following structure:
+
+```vyper
+struct Relay:
+    uri: String[MAX_STRING_LENGTH]
+    operator: String[MAX_STRING_LENGTH]
+    is_mandatory: bool
+    description: String[MAX_STRING_LENGTH]
+```
+
+where:
+
+- `uri` is the relay's URI to fetch the data
+- `operator` is the relay title or pseudonim
+- `is_mandatory` is supposed to distringuish between optional and mandatory relays
+- `description` is designated to store any additional info (unspecified at the current stage)
+
+### Adding relay
+
+To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `add_relay` method passing all necessary relay structure's params described above.
+
+### Removing relay
+
+To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `remove_relay` method passing the relay's `uri`.
+
+### Updating relay
+
+The proposed flow to update the relay's info is to re-add relay (call `remove_relay` and then `add_relay`).
+
+### Reading the current whitelisted relays
+
+Anyone is allowed to call the following methods to retrieve current relays set:
+
+- `get_relays_amount` to check how many relays are currently whitelisted by Lido DAO
+- `get_relays` to retrieve all currently whitelisted arrays
+- `get_relay_by_uri` to retrieve the whitelisted relay details by uri
+- `get_whitelist_version` to read lastly bumped version number of the whitelist
+
+### Whitelist versioning
+
+The major purpose of the proposed contract is to be used for generating configurations containing up-to-date whitelisted relays.
+
+To facilitate config generation process, contract contains previously mentioned `get_whitelist_version` view method to check whether lastly used relays whitelist was updated or not.
+
+The version bumps on every add/remove operation and doesn't have additional semantical meaning and numbering schemes.
+
+### Events
+
+All storage modification funcs emit at least one event containing all necessary data to reproduce the changes by external indexers:
+
+- `RelayAdded` (once a relay was whitelisted)
+- `RelayRemoved` (once a previously whitelisted relay was removed)
+- `RelaysUpdated` (once whitelist version bumped)
+- `ManagerChanged` (once management entity assigned or dismissed)
+
+### Permissions
+
+The contract has only one immutable owner set upon the deployment phase. I
+t's presumed that owner will be set to the [`Lido DAO Aragon Agent`](https://etherscan.io/address/0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) address.
+
+There is an additional `manager` allowed to add or remove relays (initialy is set to zero address). Only the contract's owner is allowed to assign or dismiss `manager`.
+
+## Specification
+
+We propose the following interface for `MEVBoostRelayWhitelist`.
+The code below presumes the Vyper v0.3.6 syntax.
+
+### Constructor
+
+```vyper
+@external
+def __init__(lido_agent: address)
+```
+
+Stores internally `lido_agent` as the contract's instance owner.
+Initializes `manager` with zero address (no manager is assigned).
+
+- Reverts if `lido_agent` is zero address.
+
+### Function: set_manager
+
+```vyper
+@external
+def set_manager(manager: address)
+```
+
+Set `manager` as the current management entity.
+
+- Reverts if called by anyone except owner (dao agent).
+- Reverts if `manager` is equal to the previously set value.
+- Reverts if `manager` is zero address.
+- Emits `ManagerChanged(manager)`.
+
+### Function: dismiss_manager
+
+```vyper
+@external
+def dismiss_manager()
+```
+
+Dismiss the current management entity.
+
+- Reverts if called by anyone except owner (dao agent).
+- Reverts if no `manager` was set previously.
+- Emits `ManagerChanged(empty(address))`.
+
+### Function: get_manager
+
+```vyper
+@view
+@external
+def get_manager() -> address
+```
+
+Retrieve the current manager entity (returns zero address if no entity is assigned).
+
+### Function: get_lido_dao_agent
+
+```vyper
+@view
+@external
+def get_lido_dao_agent() -> address
+```
+
+Retrieves contract's instance owner set upon construction.
+
+### Function: get_relays_amount
+
+```vyper
+@view
+@external
+def get_relays_amount() -> uint256
+```
+
+Retrieves current total amount of whitelisted relays.
+
+### Function: get_relays
+
+```vyper
+@view
+@external
+def get_relays() -> DynArray[Relay, MAX_NUM_RELAYS]
+```
+
+Retrieves all currently whitelisted relays.
+
+### Function: get_relay_by_uri
+
+```vyper
+@view
+@external
+def get_relay_by_uri(relay_uri: String[MAX_STRING_LENGTH]) -> bool
+```
+
+Reitrieves relay with the provided uri.
+
+- Reverts if no relay was found.
+
+### Function: get_whitelisted_version
+
+```vyper
+@view
+@external
+def get_whitelist_version() -> uint256:
+```
+
+Retrieves current version of the whitelisted relays set.
+
+### Function: add_relay
+
+```vyper
+@external
+def add_relay(
+    uri: String[MAX_STRING_LENGTH],
+    operator: String[MAX_STRING_LENGTH],
+    is_mandatory: bool,
+    description: String[MAX_STRING_LENGTH]
+):
+```
+
+Append relay to the whitelisted set where params correspond to the previously described [Relay structure](#Relay-information-structure).
+Bumps the whitelist version.
+
+- Reverts if called by anyone except owner (dao agent) or `manager` (if assigned).
+- Reverts if relay with provided `uri` already whitelisted.
+- Reverts if `uri` is empty.
+- Emits `RelayAdded(uri, relay)`.
+- Emits `RelaysUpdated(new_whitelist_ver)`.
+
+### Function: remove_relay
+
+```vyper
+@external
+def remove_relay(uri: String[MAX_STRING_LENGTH]):
+```
+
+Remove previously whitelisted array from the set.
+Bumps the whitelist version.
+
+- Reverts if called by anyone except owner (dao agent) or `manager` (if assigned).
+- Reverts if relay with provided `uri` is not whitelisted.
+- Reverts if `uri` is empty.
+- Emits `RelayRemoved(uri, uri)`.
+- Emits `RelaysUpdated(new_whitelist_ver)`.
+
+### Function: recover_erc20
+
+```vyper
+@external
+def recover_erc20(token: address, amount: uint256)
+```
+
+Transfers ERC20 tokens from the contract's balance to the owner (dao agent).
+
+- Reverts if `transfer` reverted.
+- Emits `ERC20Recovered(msg.sender, token, amount)`.
+- Emits `Transfer(self.address, LIDO_DAO_AGENT, amount)` of the `token`'s contract (if ERC20-compliant).
+
+### Event: RelayAdded
+
+```vyper
+event RelayAdded:
+    uri_hash: indexed(String[MAX_STRING_LENGTH])
+    relay: Relay
+```
+
+Emitted when new relay was added.
+
+See: `add_relay`.
+
+### Event: RelayRemoved
+
+```vyper
+event RelayRemoved:
+    uri_hash: indexed(String[MAX_STRING_LENGTH])
+    uri: String[MAX_STRING_LENGTH]
+```
+
+Emitted when relay was removed.
+
+See: `remove_relay`.
+
+### Event: RelaysUpdated
+
+```vyper
+event RelaysUpdated:
+    whitelist_version: indexed(uint256)
+```
+
+Emitted when either relay was added or removed.
+
+See: `add_relay`, `remove_relay`.
+
+### Event: ManagerChanged
+
+```vyper
+event RelaysUpdated:
+    new_manager: indexed(address)
+```
+
+Emitted when either new manager set or dismissed.
+
+See: `set_manager`, `dismiss_manager`.
+
+### Event: ERC20Recovered
+
+```vyper
+event ERC20Recovered:
+    requested_by: indexed(address)
+    token: indexed(address)
+    amount: uint256
+```
+
+Emitted when ERC20 tokens were recovered.
+
+See: `recover_erc20`.
+
+## Security Considerations
+
+### Upgradability and mutability
+
+The proposed contract is non-upgradable. There is immutable owner address can be set only upon construction.
+
+There is an additional entity allowed to add/remove relays. The entity is easily assignable/revokable only by the contract's owner.
+
+In case of emergency or crucial update, it would be needed to dismiss the manager (if assigned) and re-deploy new contract.
+
+### Storage modification is restricted
+
+Contract's owner (Lido DAO Aragon Agent) is eligible for any possible storage modification.
+
+Additional `manager` is supposed to be used as a management entity able to add/remove relays.
+
+To minimize entities number, it was decided also to use the owner as a token recovery recipient, having the permissionless `recover_erc20` method.
+
+### Sanity caps and limits
+
+There are following caps to prevent unlimited storage accesses and unbounded loop cases:
+
+- `MAX_STRING_LENGTH` to be used for all `String[MAX_STRING_LENGTH]` types, proposed to set its value to `1024`.
+- `MAX_NUM_RELAYS` to be used as maximum whitelisted arrays amount, proposed to set its value to `40`.
+
+## Reference implementation
+
+The reference implementation of the proposed `MEVBoostRelayWhitelist` contract is available on the [Lido GitHub](https://github.com/lidofinance/mev-boost-relay-whitelist/blob/ape-vyper/contracts/MEVBoostRelayWhitelist.vy).
+
+## Links
+
+- [Ongoing discussion draft for block proposer rewards](https://research.lido.fi/t/discussion-draft-for-lido-on-ethereum-block-proposer-rewards-policy/2817)
+- [Ethereum MEV Extraction and Rewards - Discussion & Policy Groundwork](https://research.lido.fi/t/ethereum-mev-extraction-and-rewards-discussion-policy-groundwork/2461)
+- [[Proposal] optimal MEV policy for Lido](https://research.lido.fi/t/proposal-optimal-mev-policy-for-lido/2489)
+- [LIP-12: On-chain part of the rewards distribution after the Merge](https://research.lido.fi/t/lip-12-on-chain-part-of-the-rewards-distribution-after-the-merge/1625)

--- a/LIPS/lip-17.md
+++ b/LIPS/lip-17.md
@@ -11,7 +11,7 @@ updated: 2022-09-02
 # MEV-Boost relays whitelist for Lido
 
 >DISCLAIMER. [MEV extraction policy](https://research.lido.fi/t/discussion-draft-for-lido-on-ethereum-block-proposer-rewards-policy/2817
-) for Lido DAO is an ongoing topic and not finalized yet. This proposal is about additional tech spairs.
+) for Lido DAO is an ongoing topic and has not been finalized yet. This proposal is about additional tech spares.
 
 ## Simple Summary
 
@@ -21,19 +21,19 @@ The on-chain relays whitelist is planned to be used by Node Operators participat
 
 It's proposed that Node Operators should use [`MEV-Boost`](https://github.com/flashbots/mev-boost) infrastructure developed by Flashbots to support MEV extraction through the open market mechanics as a current PBS solution that has a market fit.
 
-The proposed whitelist is intented to be a source of truth for the set of possible relays allowed to be used by Node Operators. In particular, Node Operators would use the contract to keep their software configuration up-to-date (setting the necessary relays once Lido DAO decides to update the set).
+The proposed whitelist is intended to be a source of truth for the set of possible relays allowed to be used by Node Operators. In particular, Node Operators would use the contract to keep their software configuration up-to-date (setting the necessary relays once Lido DAO updates the set).
 
 ## Mechanics
 
-The contract represents a simple registry storage.
+The contract represents simple registry storage.
 
-The storage could be accessed by anyone in a permissionless way through the disclosed `view` methods or by collecting the emitted events covering all storage modifications.
+Anyone can access the storage in a permissionless way through the disclosed `view` methods or by collecting the emitted events covering all storage modifications.
 
-Any modification of the set (i.e. internal storage modification) is allowed only by [the general Lido DAO governance process](https://lido.fi/governance#regular-process) which implemented on-chain through the Aragon voting from the initial deployment stage. However, it's still possible to assign a dedicated management entity for adding/removing relay items.
+Any modification of the set (i.e., internal storage modification) is allowed only by [the general Lido DAO governance process](https://lido.fi/governance#regular-process), which is implemented on-chain through the Aragon voting from the initial deployment stage. However, it's still possible to assign a dedicated management entity for adding/removing relay items.
 
-The proposed `MEVBoostRelayWhitelist` contract is non-upgradable and its immutable owner is intented to be initialized with the [Lido DAO Aragon Agent](https://etherscan.io/address/0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) address on mainnet upon the deployment phase.
+The proposed `MEVBoostRelayWhitelist` contract is non-upgradable, and its immutable owner is intended to be initialized with the [Lido DAO Aragon Agent](https://etherscan.io/address/0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) address on mainnet upon the deployment phase.
 
-The dedicated management `manager` entity is initialized with zero address and can be set later by the contract's owner to be able to add/remove relays. The possible candidate to bear such responsibilities without sacrificing governance security is [Easy Track](https://easytrack.lido.fi/) (in this case  [`EVMScriptExecutor (Easy Track)`](https://docs.lido.fi/deployed-contracts#easy-track) should be set as `manager`).
+The dedicated management `manager` entity is initialized with a zero address and can be set later by the contract's owner to be able to add/remove relays. The possible candidate to bear such responsibilities without sacrificing governance security is [Easy Track](https://easytrack.lido.fi/) (in this case  [`EVMScriptExecutor (Easy Track)`](https://docs.lido.fi/deployed-contracts#easy-track) should be set as `manager`).
 
 ### Relay information structure
 
@@ -50,25 +50,25 @@ struct Relay:
 where:
 
 - `uri` is the relay's URI to fetch the data
-- `operator` is the relay title or pseudonim
-- `is_mandatory` is supposed to distringuish between optional and mandatory relays
+- `operator` is the relay title or pseudonym
+- `is_mandatory` is supposed to distinguish between optional and mandatory relays
 - `description` is designated to store any additional info (unspecified at the current stage)
 
 ### Adding relay
 
-To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `add_relay` method passing all necessary relay structure's params described above.
+To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `add_relay` method, passing all necessary relay structure's params described above.
 
 ### Removing relay
 
-To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `remove_relay` method passing the relay's `uri`.
+To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `remove_relay` method, passing the relay's `uri`.
 
 ### Updating relay
 
-The proposed flow to update the relay's info is to re-add relay (call `remove_relay` and then `add_relay`).
+The proposed flow to update the relay's info is to re-add the relay (call `remove_relay` and then `add_relay`).
 
 ### Reading the current whitelisted relays
 
-Anyone is allowed to call the following methods to retrieve current relays set:
+Anyone is allowed to call the following methods to retrieve the current relays set:
 
 - `get_relays_amount` to check how many relays are currently whitelisted by Lido DAO
 - `get_relays` to retrieve all currently whitelisted arrays
@@ -77,27 +77,26 @@ Anyone is allowed to call the following methods to retrieve current relays set:
 
 ### Whitelist versioning
 
-The major purpose of the proposed contract is to be used for generating configurations containing up-to-date whitelisted relays.
+The principal purpose of the proposed contract is to be used for generating configurations containing up-to-date whitelisted relays.
 
-To facilitate config generation process, contract contains previously mentioned `get_whitelist_version` view method to check whether lastly used relays whitelist was updated or not.
+To facilitate config generation process, the contract contains the previously mentioned `get_whitelist_version` view method to check whether the lastly used relays whitelist was updated or not.
 
 The version bumps on every add/remove operation and doesn't have additional semantical meaning and numbering schemes.
 
 ### Events
 
-All storage modification funcs emit at least one event containing all necessary data to reproduce the changes by external indexers:
+All storage modification functions emit at least single event containing all necessary data to reproduce the changes by external indexers:
 
 - `RelayAdded` (once a relay was whitelisted)
 - `RelayRemoved` (once a previously whitelisted relay was removed)
 - `RelaysUpdated` (once whitelist version bumped)
-- `ManagerChanged` (once management entity assigned or dismissed)
+- `ManagerChanged` (once management entity is assigned or dismissed)
 
 ### Permissions
 
-The contract has only one immutable owner set upon the deployment phase. I
-t's presumed that owner will be set to the [`Lido DAO Aragon Agent`](https://etherscan.io/address/0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) address.
+The contract has only one immutable owner set upon the deployment phase. It's presumed that the owner will be set to the [`Lido DAO Aragon Agent`](https://etherscan.io/address/0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) address.
 
-There is an additional `manager` allowed to add or remove relays (initialy is set to zero address). Only the contract's owner is allowed to assign or dismiss `manager`.
+An additional `manager` is allowed to add or remove relays (initialy is set to zero address). Only the contract's owner is allowed to assign or dismiss `manager`.
 
 ## Specification
 
@@ -112,7 +111,7 @@ def __init__(lido_agent: address)
 ```
 
 Stores internally `lido_agent` as the contract's instance owner.
-Initializes `manager` with zero address (no manager is assigned).
+Initializes `manager` with a zero address (no manager is assigned).
 
 - Reverts if `lido_agent` is zero address.
 
@@ -123,9 +122,9 @@ Initializes `manager` with zero address (no manager is assigned).
 def set_manager(manager: address)
 ```
 
-Set `manager` as the current management entity.
+Sets `manager` as the current management entity.
 
-- Reverts if called by anyone except owner (dao agent).
+- Reverts if called by anyone except the owner (Lido DAO Agent).
 - Reverts if `manager` is equal to the previously set value.
 - Reverts if `manager` is zero address.
 - Emits `ManagerChanged(manager)`.
@@ -137,9 +136,9 @@ Set `manager` as the current management entity.
 def dismiss_manager()
 ```
 
-Dismiss the current management entity.
+Dismisses the current management entity.
 
-- Reverts if called by anyone except owner (dao agent).
+- Reverts if called by anyone except the owner (Lido DAO Agent).
 - Reverts if no `manager` was set previously.
 - Emits `ManagerChanged(empty(address))`.
 
@@ -151,7 +150,7 @@ Dismiss the current management entity.
 def get_manager() -> address
 ```
 
-Retrieve the current manager entity (returns zero address if no entity is assigned).
+Retrieves the current manager entity (returns zero address if no entity is assigned).
 
 ### Function: get_lido_dao_agent
 
@@ -161,7 +160,7 @@ Retrieve the current manager entity (returns zero address if no entity is assign
 def get_lido_dao_agent() -> address
 ```
 
-Retrieves contract's instance owner set upon construction.
+Retrieves the contract's instance owner set upon construction.
 
 ### Function: get_relays_amount
 
@@ -171,7 +170,7 @@ Retrieves contract's instance owner set upon construction.
 def get_relays_amount() -> uint256
 ```
 
-Retrieves current total amount of whitelisted relays.
+Retrieves the current total amount of whitelisted relays.
 
 ### Function: get_relays
 
@@ -181,7 +180,7 @@ Retrieves current total amount of whitelisted relays.
 def get_relays() -> DynArray[Relay, MAX_NUM_RELAYS]
 ```
 
-Retrieves all currently whitelisted relays.
+Retrieves all of the currently whitelisted relays.
 
 ### Function: get_relay_by_uri
 
@@ -191,7 +190,7 @@ Retrieves all currently whitelisted relays.
 def get_relay_by_uri(relay_uri: String[MAX_STRING_LENGTH]) -> bool
 ```
 
-Reitrieves relay with the provided uri.
+Retrieves the relay with the provided uri.
 
 - Reverts if no relay was found.
 
@@ -203,7 +202,7 @@ Reitrieves relay with the provided uri.
 def get_whitelist_version() -> uint256:
 ```
 
-Retrieves current version of the whitelisted relays set.
+Retrieves the current version of the whitelisted relays set.
 
 ### Function: add_relay
 
@@ -220,7 +219,7 @@ def add_relay(
 Append relay to the whitelisted set where params correspond to the previously described [Relay structure](#Relay-information-structure).
 Bumps the whitelist version.
 
-- Reverts if called by anyone except owner (dao agent) or `manager` (if assigned).
+- Reverts if called by anyone except the owner (Lido DAO Agent) or `manager` (if assigned).
 - Reverts if relay with provided `uri` already whitelisted.
 - Reverts if `uri` is empty.
 - Emits `RelayAdded(uri, relay)`.
@@ -236,7 +235,7 @@ def remove_relay(uri: String[MAX_STRING_LENGTH]):
 Remove previously whitelisted array from the set.
 Bumps the whitelist version.
 
-- Reverts if called by anyone except owner (dao agent) or `manager` (if assigned).
+- Reverts if called by anyone except the owner (Lido DAO Agent) or `manager` (if assigned).
 - Reverts if relay with provided `uri` is not whitelisted.
 - Reverts if `uri` is empty.
 - Emits `RelayRemoved(uri, uri)`.
@@ -249,7 +248,7 @@ Bumps the whitelist version.
 def recover_erc20(token: address, amount: uint256)
 ```
 
-Transfers ERC20 tokens from the contract's balance to the owner (dao agent).
+Transfers ERC20 tokens from the contract's balance to the owner (Lido DAO Agent).
 
 - Reverts if `transfer` reverted.
 - Emits `ERC20Recovered(msg.sender, token, amount)`.
@@ -263,7 +262,7 @@ event RelayAdded:
     relay: Relay
 ```
 
-Emitted when new relay was added.
+Emitted when a new relay was added.
 
 See: `add_relay`.
 
@@ -275,7 +274,7 @@ event RelayRemoved:
     uri: String[MAX_STRING_LENGTH]
 ```
 
-Emitted when relay was removed.
+Emitted when a relay was removed.
 
 See: `remove_relay`.
 
@@ -318,23 +317,23 @@ See: `recover_erc20`.
 
 ### Upgradability and mutability
 
-The proposed contract is non-upgradable. There is immutable owner address can be set only upon construction.
+The proposed contract is non-upgradable. There is an immutable owner address that can be set only upon construction.
 
 There is an additional entity allowed to add/remove relays. The entity is easily assignable/revokable only by the contract's owner.
 
-In case of emergency or crucial update, it would be needed to dismiss the manager (if assigned) and re-deploy new contract.
+In case of emergency or important update, it would be necessary to dismiss the manager (if assigned) and re-deploy a new contract.
 
 ### Storage modification is restricted
 
-Contract's owner (Lido DAO Aragon Agent) is eligible for any possible storage modification.
+The contract's owner (Lido DAO Aragon Agent) is eligible for any possible storage modification.
 
 Additional `manager` is supposed to be used as a management entity able to add/remove relays.
 
-To minimize entities number, it was decided also to use the owner as a token recovery recipient, having the permissionless `recover_erc20` method.
+To minimize entities number, it was decided to use the owner as a token recovery recipient, having the permissionless `recover_erc20` method.
 
 ### Sanity caps and limits
 
-There are following caps to prevent unlimited storage accesses and unbounded loop cases:
+There are the following caps to prevent unlimited storage accesses and unbounded loop cases:
 
 - `MAX_STRING_LENGTH` to be used for all `String[MAX_STRING_LENGTH]` types, proposed to set its value to `1024`.
 - `MAX_NUM_RELAYS` to be used as maximum whitelisted arrays amount, proposed to set its value to `40`.

--- a/LIPS/lip-17.md
+++ b/LIPS/lip-17.md
@@ -50,21 +50,23 @@ struct Relay:
 where:
 
 - `uri` is the relay's URI to fetch the data
-- `operator` is the relay title or pseudonym
+- `operator` is a name of the entity running the relay
 - `is_mandatory` is supposed to distinguish between optional and mandatory relays
 - `description` is designated to store any additional info (unspecified at the current stage)
 
 ### Adding relay
 
-To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `add_relay` method, passing all necessary relay structure's params described above.
+To add a new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `add_relay` method, passing all necessary relay structure's params described above.
 
 ### Removing relay
 
-To add a single new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `remove_relay` method, passing the relay's `uri`.
+To remove a new relay, `Lido DAO Aragon Agent` or `manager` (if assigned) should call `remove_relay` method, passing the relay's `uri`.
 
 ### Updating relay
 
 The proposed flow to update the relay's info is to re-add the relay (call `remove_relay` and then `add_relay`).
+
+>NB: the order of the relays in the list after re-adding might change (due to the array-based implementation).
 
 ### Reading the current whitelisted relays
 
@@ -85,7 +87,7 @@ The version bumps on every add/remove operation and doesn't have additional sema
 
 ### Events
 
-All storage modification functions emit at least single event containing all necessary data to reproduce the changes by external indexers:
+All storage modification functions emit at least a single event containing all necessary data to reproduce the changes by external indexers:
 
 - `RelayAdded` (once a relay was whitelisted)
 - `RelayRemoved` (once a previously whitelisted relay was removed)


### PR DESCRIPTION
# MEV-Boost relays whitelist for Lido

>DISCLAIMER. [MEV extraction policy](https://research.lido.fi/t/discussion-draft-for-lido-on-ethereum-block-proposer-rewards-policy/2817
) for Lido DAO is an ongoing topic and has not been finalized yet. This proposal is about additional tech spares.

## Simple Summary

The on-chain relays whitelist is planned to be used by Node Operators participating in the Lido protocol after the Merge to extract MEV according to the expected Lido policies.