### PR TITLE
Add Token Rate Oracle pause to documentation

### DIFF
--- a/LIPS/lip-22.md
+++ b/LIPS/lip-22.md
@@ -391,7 +391,7 @@ The following expectations are set for the design described.
 ### Pause Token Rate Oracle
 
 #### Reason
-The design offered earlier allows updating the token rate (sourced from L1 wstETH) on the L2 TokenRateOracle by either depositing tokens through a bridge or directly pushing the token rate via the TokenRateNotifier. Deposits can always be paused by the "deposits enabler" role, but pushing token rate cannot be paused. However, there is a risk that the protocol could be compromised, resulting in a malicious token rate being applied. Our team came up with the idea of adding pause to the TokenRateOracle updates, which would allow to react on applied malicious token rate. Additionally, making the TokenRateOracle suspendable would facilitate easier future upgrades of the TokenRateOracle.
+The design offered earlier allows updating the token rate (sourced from L1 wstETH) on the L2 TokenRateOracle by either depositing tokens through a bridge or directly pushing the token rate via the TokenRateNotifier. Deposits can always be paused by the "deposits enabler" role, but pushing token rate cannot be paused. However, there is a risk that the protocol could be compromised, resulting in a malicious token rate being applied. To mitigate this risk, adding a pause feature to the TokenRateOracle updates is proposed. This feature would enable a reaction to any applied malicious token rate. Additionally, making the TokenRateOracle suspendable would facilitate easier future upgrades of the TokenRateOracle.
 
 #### Describe Pause mechanism
 Simply pausing the TokenRateOracle update and retaining the already applied rate will not resolve the issue of an incorrect rate, as it has already been applied. There should be a mechanism to revert the rate to its previous value. The past value should be recent enough for the committee to respond effectively but not so old that it allows the committee to manipulate the rate. Reverting the rate to its value from one day prior seems reasonable, as it aligns with the original design assumptions. As for the resuming method, it should be called with the most recent token rate.
@@ -422,9 +422,7 @@ To understand how pause/resume will work, let's examine a table of typical data 
 TokenRate stores in the array all elements in the format [TokenRate + L1TimeUpgrade + L2TimeReceived], ensuring not to add elements with the same L1TimeUpgrade value. After this input, the array of token rates will look like this: `[{1.1, 0d, 0d+23h}, { 1.2, 1d, 2d+2h}]`. Considering all the logic described above and input data, it will be possible to revert only to the last element with a pause.
 
 #### Pause impact on protocol
-Pause won't revert the transaction and just emits an event if a token rate update is called.
-
-Let's check deposit/withdrawal/rate pause combinations and what impact on protocol they have.
+Pause won't revert the transaction and just emits an event if a token rate update is called. Here are deposit/withdrawal/rate pause combinations and what impact on protocol they have.
 
 | Deposit/Withdrawal Disabled | TokenRateOracle Paused| result |
 |--------|--------|--------|

--- a/LIPS/lip-22.md
+++ b/LIPS/lip-22.md
@@ -388,6 +388,52 @@ The following expectations are set for the design described.
 
 ## Security considerations
 
+### Pause Token Rate Oracle
+
+#### Reason
+The design offered earlier allows updating the token rate (sourced from L1 wstETH) on the L2 TokenRateOracle by either depositing tokens through a bridge or directly pushing the token rate via the TokenRateNotifier. Deposits can always be paused by the "deposits enabler" role, but pushing token rate cannot be paused. However, there is a risk that the protocol could be compromised, resulting in a malicious token rate being applied. Our team came up with the idea of adding pause to the TokenRateOracle updates, which would allow to react on applied malicious token rate. Additionally, making the TokenRateOracle suspendable would facilitate easier future upgrades of the TokenRateOracle.
+
+#### Describe Pause mechanism
+Simply pausing the TokenRateOracle update and retaining the already applied rate will not resolve the issue of an incorrect rate, as it has already been applied. There should be a mechanism to revert the rate to its previous value. The past value should be recent enough for the committee to respond effectively but not so old that it allows the committee to manipulate the rate. Reverting the rate to its value from one day prior seems reasonable, as it aligns with the original design assumptions. As for the resuming method, it should be called with the most recent token rate.
+
+#### Technical details
+Pause method should be called with rate element index, the rate should be applied if the index corresponds to the last element, or if the element is not older (i.e., refreshed) than one day. Any remaining elements would be deleted as they are considered malicious. Additionally, to prevent the array from being filled with many elements (which could be difficult to delete due to gas usage), the update rate should be filtered based on the frequency of rate updates.
+
+To understand how pause/resume will work, let's examine a table of typical data that the updateRate function will be called with, and what exactly the oracle will store.
+
+| Rate       | L1TimeUpdate      | L2TimeReceived |
+|--------|--------|--------|
+|Report 1 happened|
+|1.1|0 days|0 days + 1 hour|
+|1.1|0 days|0 days + 2 hours|
+|1.1|0 days|0 days + 3 hours|
+|....|
+|1.1|0 days|0 days + 23 hours|
+|Report 2 happened|
+|1.2|1 day|1 day + 1 hour|
+|1.2|1 day|1 day + 2 hours|
+|1.2|1 day|1 day + 3 hours|
+|....|
+|1.2|1 day|1 day + 23 hours|
+|3rd report delayed|
+|1.2|1 day|2 days + 1 hours|
+|1.2|1 day|2 days + 2 hours|
+
+TokenRate stores in the array all elements in the format [TokenRate + L1TimeUpgrade + L2TimeReceived], ensuring not to add elements with the same L1TimeUpgrade value. After this input, the array of token rates will look like this: `[{1.1, 0d, 0d+23h}, { 1.2, 1d, 2d+2h}]`. Considering all the logic described above and input data, it will be possible to revert only to the last element with a pause.
+
+#### Pause impact on protocol
+Pause won't revert the transaction and just emits an event if a token rate update is called.
+
+Let's check deposit/withdrawal/rate pause combinations and what impact on protocol they have.
+
+| Deposit/Withdrawal Disabled | TokenRateOracle Paused| result |
+|--------|--------|--------|
+|false|false|everything works, deposit, withdrawals and pushing rate|
+|false|true|Since oracle pause doesn't revert users can deposit/withdrawal but rate won't be updated.|
+|true|false|users can't deposit/withdrawal but pushing rate by TokenRateNotifier is still possible|
+|true|true|both flows are paused|
+
+
 ### Cross-domain token rate arbitrage
 
 #### Risks analysis


### PR DESCRIPTION
Update LIP-22 with new feature that pauses and resumes token rate updates