### PR TITLE
update lip statuses

### DIFF
--- a/LIPS/lip-33.md
+++ b/LIPS/lip-33.md
@@ -1,11 +1,11 @@
 ---
 lip: 33
 title: Community Staking Module v3 and Curated Module v2
-status: Approved
+status: Implemented
 author: Dmitry Gusakov (@dgusakov), Sergey Khomutinin (@skhomuti), Dmitry Chernukhin (@madlabman), Vladimir Gorkavenko (@vgorkavenko)
 discussions-to: https://research.lido.fi/t/community-staking-module/5917, https://research.lido.fi/t/future-of-the-curated-module-cmv2-landscape/10929
 created: 2026-03-18
-updated: 2026-06-29
+updated: 2026-08-13
 ---
 
 # LIP-33. Community Staking Module v3 and Curated Module v2

--- a/LIPS/lip-35.md
+++ b/LIPS/lip-35.md
@@ -1,11 +1,11 @@
 ---
 lip: 35
 title: Staking Router v3
-status: Approved
+status: Implemented
 author: Maksim Kuraian (@mkurayan) , KRogLA (@KRogLA), Alexander Kolesnikov (@eddort), Anna Mukharram (@Amuhar)
 discussions-to: https://research.lido.fi/t/staking-router-v3-design-implementation-proposal-lip-35/11621
 created: 2026-05-22
-updated: 2026-06-29
+updated: 2026-08-13
 ---
 
 # LIP-35. Staking Router v3


### PR DESCRIPTION
This pull request updates the status and metadata of two Lido Improvement Proposals (LIPs) to reflect their implementation. Both LIP-33 and LIP-35 are now marked as "Implemented," and their last updated dates have been changed to August 13, 2026.